### PR TITLE
from changed? to saved_changes?

### DIFF
--- a/lib/record_with_operator/recorder.rb
+++ b/lib/record_with_operator/recorder.rb
@@ -11,7 +11,7 @@ module RecordWithOperator
     end
 
     def set_updater
-      return unless changed? # no use setting updating_by when it's not changed
+      return unless saved_changes? # no use setting updating_by when it's not changed
       return unless operator # avoid changing value to be nil
       send("#{RecordWithOperator.updater_column}=", operator.id)
     end


### PR DESCRIPTION
# 概要
Rails5系でrspec実行時にwarningが表示されるため

## 受入基準
- `changed?` のコードが `saved_changes?` に変更されている
- 他のアプリでこのGemを呼んだ際、rspec実行時にwarningが表示されない

## warning例
```
DEPRECATION WARNING: The behavior of `changed?` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_changes?` instead. (called from set_accounting_software_default at /Users/mika/dev/mb/app/models/company.rb:285)
```
```
DEPRECATION WARNING: The behavior of `changed_attributes` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `saved_changes.transform_values(&:first)` instead. (called from set_accounting_software_default at /Users/mika/dev/mb/app/models/company.rb:285)
```